### PR TITLE
Fix fatal error on php8 when cleaning up records

### DIFF
--- a/core/components/akismet/src/Akismet.php
+++ b/core/components/akismet/src/Akismet.php
@@ -298,7 +298,7 @@ class Akismet {
                     'created_at:<' => $deleteBefore
                 ]);
                 $this->modx->log(modX::LOG_LEVEL_INFO, '[Akismet] Cleaned up ' . $count
-                    . ' spam analysis records from before ' . date('Y-m-d H:i:s', $deleteBefore));
+                    . ' spam analysis records from before ' . $deleteBefore);
             }
         }
     }


### PR DESCRIPTION
Untested

Fatal error: Uncaught TypeError: date(): Argument #2 ($timestamp) must be of type ?int, string given in core/components/akismet/src/Akismet.php:301 Stack trace: #0 /home/clients/fa26d812a5cb82deda0e9bbc2e8f843f/web/core/components/akismet/src/Akismet.php(301): date('Y-m-d H:i:s', '2023-03-12 11:2...') 

https://secure.helpscout.net/conversation/2209997401/35434?folderId=46279